### PR TITLE
leave off the "| r" in pureST

### DIFF
--- a/docs/Control/Monad/ST.md
+++ b/docs/Control/Monad/ST.md
@@ -68,7 +68,7 @@ It may cause problems to apply this function using the `$` operator. The recomme
 #### `pureST`
 
 ``` purescript
-pureST :: forall a. (forall h r. Eff (st :: ST h | r) a) -> a
+pureST :: forall a. (forall h. Eff (st :: ST h) a) -> a
 ```
 
 A convenience function which combines `runST` with `runPure`, which can be used when the only required effect is `ST`.

--- a/src/Control/Monad/ST.purs
+++ b/src/Control/Monad/ST.purs
@@ -38,5 +38,5 @@ foreign import runST :: forall a r. (forall h. Eff (st :: ST h | r) a) -> Eff r 
 -- |
 -- | Note: since this function has a rank-2 type, it may cause problems to apply this function using the `$` operator. The recommended approach
 -- | is to use parentheses instead.
-pureST :: forall a. (forall h r. Eff (st :: ST h | r) a) -> a
+pureST :: forall a. (forall h. Eff (st :: ST h) a) -> a
 pureST st = runPure (runST st)


### PR DESCRIPTION
Per discussion with paf31 in #purescript. This was written the old way to follow the lead of runPure, but now that we have empty row syntax runPure doesn't have to be written that way (see https://github.com/purescript/purescript-eff/pull/7) so let's write this type a bit more clearly.

I can't say I have a completely solid grasp on rank-n types or Eff/row types so I'm not certifying the correctness of this, just pushing the buttons based on my understanding of what was discussed in #purescript.