### PR TITLE
Get rid of Eff dependency, add Region kind.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,10 @@
     "bower.json",
     "package.json"
   ],
+  "devDependencies": {
+    "purescript-console": "^3.0.0"
+  },
   "dependencies": {
-    "purescript-eff": "^3.0.0"
+    "purescript-prelude": "^3.1.1"
   }
 }

--- a/src/Control/Monad/ST.js
+++ b/src/Control/Monad/ST.js
@@ -1,5 +1,27 @@
 "use strict";
 
+exports.mapST = function (f) {
+  return function (a) {
+    return function () {
+      return f(a());
+    };
+  };
+};
+
+exports.pureST_ = function (a) {
+  return function () {
+    return a;
+  };
+};
+
+exports.bindST_ = function (a) {
+  return function (f) {
+    return function () {
+      return f(a())();
+    };
+  };
+};
+
 exports.newSTRef = function (val) {
   return function () {
     return { value: val };
@@ -28,6 +50,6 @@ exports.writeSTRef = function (ref) {
   };
 };
 
-exports.runST = function (f) {
-  return f;
+exports.pureST = function (f) {
+  return f();
 };

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,20 @@
+module Test.Main where
+
+import Prelude
+
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, logShow)
+import Control.Monad.ST (modifySTRef, newSTRef, readSTRef, pureST)
+
+sumOfSquares :: Int
+sumOfSquares = pureST do
+  total <- newSTRef 0
+  let loop 0 = readSTRef total
+      loop n = do
+        _ <- modifySTRef total (_ + (n * n))
+        loop (n - 1)
+  loop 100
+
+main :: Eff (console :: CONSOLE) Unit
+main = do
+  logShow sumOfSquares


### PR DESCRIPTION
I wasn't sure if anyone was working on this, but it seemed simple enough.

Obviously there are optimizer changes needed to support something like this.

I wasn't able to use the name `runST` because of the way that function currently gets inlined, so that will need some thought if we would like users to be able to use the old library version with the new compiler, and vice versa.