### PR TITLE
Added Distributive instance and test

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "purescript-prelude": "^4.0.0",
     "purescript-tailrec": "^4.0.0",
-    "purescript-partial": "^2.0.0"
+    "purescript-partial": "^2.0.0",
+    "purescript-distributive": "^4.0.0"
   },
   "devDependencies": {
     "purescript-console": "^4.0.0"

--- a/src/Control/Monad/ST/Internal.js
+++ b/src/Control/Monad/ST/Internal.js
@@ -22,6 +22,16 @@ exports.bind_ = function (a) {
   };
 };
 
+exports.distribute_ = function (map_a) {
+  return function (a) {
+    return function () {
+      return map_a(function(f){
+        return f();
+      })(a);
+    };
+  };
+};
+
 exports.run = function (f) {
   return f();
 };

--- a/src/Control/Monad/ST/Internal.purs
+++ b/src/Control/Monad/ST/Internal.purs
@@ -3,6 +3,7 @@ module Control.Monad.ST.Internal where
 import Prelude
 
 import Control.Monad.Rec.Class (class MonadRec, Step(..))
+import Data.Distributive (class Distributive, collectDefault)
 import Partial.Unsafe (unsafePartial)
 
 -- | `ST` is concerned with _restricted_ mutation. Mutation is restricted to a
@@ -24,6 +25,8 @@ foreign import map_ :: forall r a b. (a -> b) -> ST r a -> ST r b
 foreign import pure_ :: forall r a. a -> ST r a
 
 foreign import bind_ :: forall r a b. ST r a -> (a -> ST r b) -> ST r b
+
+foreign import distribute_ :: forall r a f. ((ST r a -> a) -> f (ST r a) -> f a) -> f (ST r a) -> ST r (f a)
 
 instance functorST :: Functor (ST r) where
   map = map_
@@ -56,6 +59,10 @@ instance monadRecST :: MonadRec (ST r) where
       isLooping = case _ of
         Loop _ -> true
         _ -> false
+
+instance distributiveST :: Distributive (ST r) where
+  distribute = distribute_ map
+  collect = collectDefault
 
 -- | Run an `ST` computation.
 -- |

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,6 +6,7 @@ import Effect (Effect)
 import Effect.Console (logShow)
 import Control.Monad.ST as ST
 import Control.Monad.ST.Ref as STRef
+import Data.Distributive (distribute)
 
 sumOfSquares :: Int
 sumOfSquares = ST.run do
@@ -16,6 +17,16 @@ sumOfSquares = ST.run do
         loop (n - 1)
   loop 100
 
+distributeAp :: Int
+distributeAp = ST.run (distribute f <*> pure 1337)
+  where
+    f :: forall r. Int -> ST.ST r Int
+    f i = do
+      r <- STRef.new 42
+      _ <- STRef.modify (_ + i) r
+      STRef.read r
+
 main :: Effect Unit
 main = do
   logShow sumOfSquares
+  logShow distributeAp


### PR DESCRIPTION
I haven't thoroughly checked how law abiding this is, but thought it might be useful.

My motivation for this was to be able to partially apply a function which produces an ST given some non-ST arguments, and have the result still be in ST.

Specifically, I have a DSL which has a statement like 
```purescript
assign :: forall a. repr (a -> state) -> repr a -> repr state -> repr state
assign setter value next_statement = ...
```
where `repr a` must be evaluated on the state before setter and next_statement.

When `repr ~ (->) state` this is not an issue, but when `repr ~ ST r` (and `state ~ Unit`), my state modification functions will be of type `f :: a -> ST r Unit` which require something like `pure (\a -> run (f a))` to make the types match, which fails due to mismatching `r` type variables.

Adding a distributive instance allows us to take `a -> ST r Unit` to `ST r (a -> Unit)` via the functor `(->) a`.

Of course, I could use `repr a -> repr state` instead of `repr (a -> state)`, but this makes things more difficult elsewhere.