### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Control/Monad/ST/Internal.purs
+++ b/src/Control/Monad/ST/Internal.purs
@@ -19,6 +19,8 @@ data Region
 -- | The `run` function can be used to run a computation in the `ST` monad.
 foreign import data ST :: Region -> Type -> Type
 
+type role ST nominal representational
+
 foreign import map_ :: forall r a b. (a -> b) -> ST r a -> ST r b
 
 foreign import pure_ :: forall r a. a -> ST r a
@@ -88,6 +90,8 @@ foreign import foreach :: forall r a. Array a -> (a -> ST r Unit) -> ST r Unit
 -- | The type `STRef r a` represents a mutable reference holding a value of
 -- | type `a`, which can be used with the `ST r` effect.
 foreign import data STRef :: Region -> Type -> Type
+
+type role STRef nominal representational
 
 -- | Create a new mutable reference.
 foreign import new :: forall a r. a -> ST r (STRef r a)


### PR DESCRIPTION
This allows terms of type `ST r a` and `STRef r a` to be coerced to type `ST r b` and `STRef r b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under ST computations and mutable references for instance.

I couldn’t think of a case where a phantom roled region is an issue but in doubt I preferred to keep it nominal.